### PR TITLE
Bugfix: Cursor.prev_line

### DIFF
--- a/lib/tty/cursor.rb
+++ b/lib/tty/cursor.rb
@@ -118,7 +118,7 @@ module TTY
 
     # @api public
     def prev_line
-      ECMA_CSI + 'F'
+      ECMA_CSI + 'A' + ECMA_CSI + '1G'
     end
 
     # Clear current line

--- a/spec/unit/cursor_spec.rb
+++ b/spec/unit/cursor_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TTY::Cursor do
     expect(cursor.restore).to eq("\e[u")
   end
 
-  it "gets current cursor positoin" do
+  it "gets current cursor position" do
     expect(cursor.current).to eq("\e[6n")
   end
 

--- a/spec/unit/cursor_spec.rb
+++ b/spec/unit/cursor_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TTY::Cursor do
   end
 
   it "moves cursor to previous line" do
-    expect(cursor.prev_line).to eq("\e[F")
+    expect(cursor.prev_line).to eq("\e[A\e[1G")
   end
 
   it "hides cursor for the duration of block call" do


### PR DESCRIPTION
Spotted this bug in iTerm2.
I _think_ PuTTy was probably also affected (but have no windows machine to test).
