### PR TITLE
Use DEC sequences for #save and #restore

### DIFF
--- a/lib/tty/cursor.rb
+++ b/lib/tty/cursor.rb
@@ -35,13 +35,17 @@ module TTY
     # Save current position
     # @api public
     def save
-      CSI + 's'
+      return CSI + 's' if Gem.win_platform?
+
+      ESC + "7"
     end
 
     # Restore cursor position
     # @api public
     def restore
-      CSI + 'u'
+      return CSI + 'u' if Gem.win_platform?
+
+      ESC + "8"
     end
 
     # Query cursor current position

--- a/spec/unit/cursor_spec.rb
+++ b/spec/unit/cursor_spec.rb
@@ -12,10 +12,22 @@ RSpec.describe TTY::Cursor do
   end
 
   it "saves cursor position" do
+    expect(cursor.save).to eq("\e7")
+  end
+
+  it "saves cursor position on Windows" do
+    allow(Gem).to receive(:win_platform?).and_return(true)
+
     expect(cursor.save).to eq("\e[s")
   end
 
   it "restores cursor position" do
+    expect(cursor.restore).to eq("\e8")
+  end
+
+  it "restores cursor position on Windows" do
+    allow(Gem).to receive(:win_platform?).and_return(true)
+
     expect(cursor.restore).to eq("\e[u")
   end
 


### PR DESCRIPTION
Previously it used the CSI sequences for #save and #restore, but these
sequences are not supported on some terminals such as Mac's Terminal.app
runing 'xterm-256color'. The DEC sequence seems to be more widely
supported (with the exception of Windows Powershell, which only supports
the CSI sequences).

Fixes #3