### PR TITLE
(MAINT) Allow #win_platform? to return based on OS

### DIFF
--- a/spec/unit/cursor_spec.rb
+++ b/spec/unit/cursor_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe TTY::Cursor do
   end
 
   it "restores cursor position" do
+    allow(Gem).to receive(:win_platform?).and_return(false)
+
     expect(cursor.restore).to eq("\e8")
   end
 


### PR DESCRIPTION
This should make it work in AppVeyor too :) 