### PR TITLE
Add rbs signatures

### DIFF
--- a/sig/tty/cursor.rbs
+++ b/sig/tty/cursor.rbs
@@ -1,0 +1,54 @@
+module TTY
+  module Cursor
+    def self.backward: (Integer n) -> String
+    alias self.cursor_backward self.backward
+
+    def self.column: (Integer n) -> String
+
+    def self.clear_char: (?Integer? n) -> String
+
+    def self.clear_line: () -> String
+
+    def self.clear_line_after: () -> String
+
+    def self.clear_line_before: () -> String
+
+    def self.clear_lines: (Integer n, ?Symbol? direction) -> String
+    alias self.clear_rows self.clear_lines
+
+    def self.clear_screen: () -> String
+
+    def self.clear_screen_down: () -> String
+
+    def self.clear_screen_up: () -> String
+
+    def self.current: () -> String
+
+    def self.down: (Integer n) -> String
+    alias self.cursor_down self.down
+
+    def self.forward: (Integer n) -> String
+    alias self.cursor_forward self.forward
+
+    def self.move: (Integer x, Integer y) -> String
+
+    def self.move_to: (Integer x, Integer y) -> String
+
+    def self.next_line: () -> String
+
+    def self.prev_line: () -> String
+
+    def self.restore: () -> String
+
+    def self.row: (Integer n) -> String
+
+    def self.save: () -> String
+
+    def self.scroll_down: () -> String
+
+    def self.scroll_up: () -> String
+
+    def self.up: (Integer n) -> String
+    alias self.cursor_up self.up
+  end
+end

--- a/tty-cursor.gemspec
+++ b/tty-cursor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
       "source_code_uri"   => "https://github.com/piotrmurach/tty-cursor"
     }
   end
-  spec.files         = Dir["lib/**/*", "README.md", "CHANGELOG.md", "LICENSE.txt"]
+  spec.files         = Dir["lib/**/*", "sig/**/*", "README.md", "CHANGELOG.md", "LICENSE.txt"]
   spec.extra_rdoc_files = ["README.md", "CHANGELOG.md"]
   spec.bindir        = "exe"
   spec.require_paths = ["lib"]


### PR DESCRIPTION
### Describe the change

This adds RBS signatures for the Cursor module

### Why are we doing this?

To provide RBS signatures for consumers of the tty-cursor gem

### Benefits

Dependents don't have to maintain their own copies of the signatures for tty-cursor

### Drawbacks

Its another thing to maintain

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [ ] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
